### PR TITLE
Split out powershell bootstrap stuff that required admin rights

### DIFF
--- a/script/bin/admin.ps1
+++ b/script/bin/admin.ps1
@@ -1,0 +1,84 @@
+function Assert-Latest-PowerShell-Installed {
+  $psCoreInstalled = $false
+  if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+    $psCoreInstalled = $true
+  }
+  if ($psCoreInstalled -eq $false) {
+    $psPackageName = "Microsoft.PowerShell"
+    Write-Output "===> Installing '$psPackageName' using winget"
+    winget install $psPackageName --exact
+  }
+}
+
+# Check for Admininstrator permissions
+if (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+  Write-Output "Script is being run as Administrator"
+} else {
+  # Re-run the script using RunAs to elevate permissions
+  Write-Warning "Script needs Administrator permissions so spawning elevated version"
+  Start-Sleep 1
+  Assert-Latest-PowerShell-Installed
+  Start-Process pwsh "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs -Wait
+  exit
+}
+
+# Setup path variables
+$binPath = Split-Path -Path $PSCommandPath -Parent
+$scriptPath = Split-Path -Path $binPath -Parent
+$basePath = Split-Path -Path $scriptPath -Parent
+
+# Ensure Chocolatey is setup
+& "$binPath\installChocolatey.ps1"
+if ($LastExitCode) {
+  Write-Output "Install/upgrade of Chocolatey failed with exit code: $LastExitCode"
+  Exit $LastExitCode
+}
+
+function Install-ChocolateyPackage {
+  param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Name
+  )
+  Write-Output "===> Installing '$Name' using Chocolatey"
+  choco upgrade $Name --confirm
+}
+
+# Install any required Chocolatey packages
+$packagesFilePath = "$basePath\chocolatey-packages"
+if (Test-Path -Path "$packagesFilePath" -PathType Leaf) {
+  Write-Output "`n==> Installing Chocolatey packages..."
+  $packageList = Get-Content -Path "$packagesFilePath"
+  if ($packageList.Count -eq 1) {
+    # A single item is treated as a string not an array
+    Install-ChocolateyPackage -Name $packageList
+  } else {
+    For ($index = 0; $index -lt $packageList.Count; $index++) {
+      $package = $packageList[$index];
+      Install-ChocolateyPackage -Name $package
+    }
+  }
+}
+
+# Call Chocolatey script to apply changes to the current sessions environment
+Update-SessionEnvironment
+
+# If package.json file exists then ensure Node.js is intalled as `nvm use` requires admin rights
+$packageJson = "$basePath\package.json"
+if (Test-Path -Path "$packageJson" -PathType Leaf) {
+  # Setup appropriate version of Node.js from .nvmrc
+  $nvmrc = "$basePath\.nvmrc"
+  if (Test-Path -Path "$nvmrc" -PathType Leaf) {
+    Write-Output "`n==> Installing appropriate version of Node.js..."
+    $nodeVersion = Get-Content -Path "$nvmrc"
+    nvm install $nodeVersion
+    nvm use $nodeVersion
+  }
+  Write-Output "Where is npm running from:"
+  where.exe npm
+  Write-Output "What version of npm:"
+  npm -v
+}
+
+# Wait for user response in case this was spawned as a separate process
+Read-Host -Prompt "`nPress <ENTER> to continue"

--- a/script/bin/bootstrap.ps1
+++ b/script/bin/bootstrap.ps1
@@ -1,5 +1,23 @@
 Write-Output "`n==> Bootstrapping dependencies..."
 
+# Setup path variables
+$binPath = Split-Path -Path $PSCommandPath -Parent
+$scriptPath = Split-Path -Path $binPath -Parent
+$basePath = Split-Path -Path $scriptPath -Parent
+
+# Install anything that requires admin priviledges
+$packagesFilePath = "$basePath\chocolatey-packages"
+$chocolateyPackages = Test-Path -Path "$packagesFilePath" -PathType Leaf
+$packageJson = "$basePath\package.json"
+$nodePackages = Test-Path -Path "$packageJson" -PathType Leaf
+if ($chocolateyPackages -Or $nodePackages) {
+  & "$binPath\admin.ps1"
+  if ($LastExitCode) {
+    Write-Output "Admin script failed with exit code: $LastExitCode"
+    Exit $LastExitCode
+  }
+}
+
 function Install-WinGetPackage {
   param (
     [Parameter(Mandatory = $true)]
@@ -9,68 +27,6 @@ function Install-WinGetPackage {
   Write-Output "===> Installing '$Name' using winget"
   # Enforce use of exact package name as name matching can cause issues if multiple matches found
   winget install $Name --exact
-}
-
-function Assert-Latest-PowerShell-Installed {
-  $psCoreInstalled = $false
-  if (Get-Command pwsh -ErrorAction SilentlyContinue) {
-    $psCoreInstalled = $true
-  }
-  if ($psCoreInstalled -eq $false) {
-    Install-WinGetPackage -Name Microsoft.PowerShell
-  }
-}
-
-# Check for Admininstrator permissions
-if (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-  Write-Output "Script is being run as Administrator"
-} else {
-  # Re-run the script using RunAs to elevate permissions
-  Write-Warning "Script needs Administrator permissions so spawning elevated version"
-  Start-Sleep 1
-  Assert-Latest-PowerShell-Installed
-  Start-Process pwsh "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs -Wait
-  exit
-}
-
-# Setup path variables
-$binPath = Split-Path -Path $PSCommandPath -Parent
-$scriptPath = Split-Path -Path $binPath -Parent
-$basePath = Split-Path -Path $scriptPath -Parent
-
-# There are multiple places to install a package so pull code into common function
-function Install-ChocolateyPackage {
-  param (
-    [Parameter(Mandatory = $true)]
-    [string]
-    $Name
-  )
-  Write-Output "===> Installing '$Name' using Chocolatey"
-  choco upgrade $Name --confirm
-}
-
-# Install any required Chocolatey packages
-$packagesFilePath = "$basePath\chocolatey-packages"
-if (Test-Path -Path "$packagesFilePath" -PathType Leaf) {
-  # Ensure Chocolatey is setup
-  & "$binPath\installChocolatey.ps1"
-  if ($LastExitCode) {
-    Write-Output "Install/upgrade of Chocolatey failed with exit code: $LastExitCode"
-    Exit $LastExitCode
-  }
-
-  Write-Output "`n==> Installing Chocolatey packages..."
-  $packageList = Get-Content -Path "$packagesFilePath"
-  if ($packageList.Count -eq 1) {
-    # A single item is treated as a string not an array
-    Install-ChocolateyPackage -Name $packageList
-  } else {
-    For ($index = 0; $index -lt $packageList.Count; $index++) {
-      $package = $packageList[$index];
-      Install-ChocolateyPackage -Name $package
-    }
-  }
-  Update-SessionEnvironment
 }
 
 # Install any required winget packages
@@ -90,17 +46,7 @@ if (Test-Path -Path "$packagesFilePath" -PathType Leaf) {
 }
 
 # If package.json file exists then ensure Node.js is setup and run `npm install`
-$packageJson = "$basePath\package.json"
-if (Test-Path -Path "$packageJson" -PathType Leaf) {
-  # Setup appropriate version of Node.js from .nvmrc
-  $nvmrc = "$basePath\.nvmrc"
-  if (Test-Path -Path "$nvmrc" -PathType Leaf) {
-    Write-Output "`n==> Installing appropriate version of Node.js..."
-    $nodeVersion = Get-Content -Path "$nvmrc"
-    nvm install $nodeVersion
-    nvm use $nodeVersion
-  }
-
+if ($nodePackages) {
   Write-Output "`n==> Installing npm dependencies..."
   Push-Location "$basePath"
   Write-Output "Change directory to: $(Get-Location)"
@@ -113,10 +59,9 @@ if (Test-Path -Path "$packageJson" -PathType Leaf) {
   npm install
   Write-Output "Checking for outdated packages..."
   npm outdated
+  # Ignore exit code as we don't care if there are outdate packages, we just want to display them
+  $global:LASTEXITCODE = 0
 
   Pop-Location
   Write-Output "Change directory back to: $(Get-Location)"
 }
-
-# Wait for user response in case this was spawned as a separate process
-Read-Host -Prompt "`nPress <ENTER> to continue"


### PR DESCRIPTION
Rather than run the whole bootstrap script as admin I thought it made sense to pull out the bits that require it into a new script then even if the admin elevation is ignored you still get updated npm packages etc.